### PR TITLE
Rounding to integer instead of float

### DIFF
--- a/src/Classes/Json/EnergyMeter.php
+++ b/src/Classes/Json/EnergyMeter.php
@@ -151,7 +151,7 @@ abstract class EnergyMeter extends PowerSensor {
                 // day or month file, no power values
                 unset($result[Properties::POWER]);
                 // Minutes file, round energies
-                $result[Properties::ENERGY] = array_map('round', $result[Properties::ENERGY]);
+                $result[Properties::ENERGY] = array_map('intval', $result[Properties::ENERGY]);
             }
         }
 

--- a/src/Classes/Json/PowerSensor.php
+++ b/src/Classes/Json/PowerSensor.php
@@ -101,7 +101,7 @@ abstract class PowerSensor extends Json {
 
         if ($flags & self::EXPORT_POWER) {
             // Minutes file, round powers
-            $result[Properties::POWER] = array_map('round', $result[Properties::POWER]);
+            $result[Properties::POWER] = array_map('intval', $result[Properties::POWER]);
         }
 
         return $result;

--- a/src/Classes/Json/Set.php
+++ b/src/Classes/Json/Set.php
@@ -276,7 +276,7 @@ class Set extends Json implements \ArrayAccess, \Countable, \Iterator {
             // Buffer datetime format :-)
             $format = Helper::getDateFormat();
             foreach ($this->data as $timestamp=>$value) {
-                $data[date($format, $timestamp)] = round($value);
+                $data[date($format, $timestamp)] = (int)$value;
             }
         } else {
             // Return data as is


### PR DESCRIPTION
Changes are necessary to round the float values to integers instead of only dropping the decimal places. Without the change the resulting JSON couldn't be validated successfully.